### PR TITLE
Add scheduled role creation logic and policy scheduler tests

### DIFF
--- a/steps/composition_tester.py
+++ b/steps/composition_tester.py
@@ -231,6 +231,16 @@ def check_no_resources(ctx: Context):
         ctx, CTX_DESIRED_RESOURCES, assert_exists=False)
     check_resources_are_empty(desired_resources)
 
+@then('rendering fails with error message containing "{expected_error}"')
+def fail_with_error(ctx: Context, expected_error: str):
+    args = prepare_render_args(ctx)
+    out = subprocess.run(args, capture_output=True, text=True)
+
+    allure.attach(out.stdout, name="render stdout")
+    allure.attach(out.stderr, name="render stderr")
+
+    assert out.returncode != 0, "Expected render to fail but it succeeded"
+    assert expected_error in out.stderr, f"Expected error '{expected_error}' not found in stderr: {out.stderr}"
 
 @step("check that {resource_count:d} resource is provisioning")
 @step("check that {resource_count:d} resources are provisioning")

--- a/test/composition-tests/envconfig.yaml
+++ b/test/composition-tests/envconfig.yaml
@@ -5,3 +5,4 @@ metadata:
 data:
   accountId: "1234"
   region: "eu-central-1"
+  eksOID: "4321"

--- a/test/composition-tests/policy-scheduler/main.feature
+++ b/test/composition-tests/policy-scheduler/main.feature
@@ -1,0 +1,33 @@
+# Copyright 2023 Swisscom (Schweiz) AG
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@PolicyScheduler
+Feature: Policy scheduler composition
+  Tests the policy scheduler composition
+
+  Background:
+    Given input claim xr.yaml
+    # following step is optional: default input composition is composition.yaml 
+    And input composition composition.yaml
+    # following step is optional: default input functions is functions.yaml
+    And input functions functions.yaml
+    Then check that no resources are provisioning
+
+  @normal
+  Scenario: TODO
+
+    # render 1
+    When crossplane renders the composition
+    Then check that no resources are provisioning
+    # TODO follow the example from service-account.feature and write similar steps to test the policy scheduler composition

--- a/test/composition-tests/policy-scheduler/main.feature
+++ b/test/composition-tests/policy-scheduler/main.feature
@@ -24,10 +24,85 @@ Feature: Policy scheduler composition
     And input functions functions.yaml
     Then check that no resources are provisioning
 
-  @normal
-  Scenario: TODO
+  @critical
+  Scenario: create role within the scheduled window
 
     # render 1
+    Given input claim is changed with parameters
+      | param name                      | param value          |
+      | spec.schedules[0].scheduleFrom  | 2025-01-01T00:00:00Z |
+      | spec.schedules[0].scheduleUntil | 2025-12-31T00:00:00Z |
+      | spec.schedules[1].scheduleFrom  | 2025-01-01T00:00:00Z |
+      | spec.schedules[1].scheduleUntil | 2025-12-31T00:00:00Z |
+    When crossplane renders the composition
+    Then check that 2 resources are provisioning
+      | resource-name    |
+      | role-app-1-rpa   |
+      | role-app-2-rpa   |
+
+    # render 2
+    Given change following observed resources with status READY
+      | resource-name  |
+      | role-app-1     |
+      | role-app-2     |
+    When crossplane renders the composition
+    Then check that 4 resources are provisioning and they are
+      | resource-name  |
+      | role-app-1     |
+      | role-app-2     |
+      | role-app-1-rpa |
+      | role-app-2-rpa |
+    And check that resource role-app-1-rpa has parameters
+      | param name                 | param value |
+      | spec.forProvider.roleName  | role-app-1  |
+      | spec.forProvider.policyArn | arn:aws:iam::aws:policy/AmazonPolicy1  |
+    And check that resource role-app-2-rpa has parameters
+      | param name                 | param value |
+      | spec.forProvider.roleName  | role-app-2  |
+      | spec.forProvider.policyArn | arn:aws:iam::aws:policy/AmazonPolicy2  |
+
+  @critial
+  Scenario: prevent creating role outside schedule window
+
+    Given input claim is changed with parameters
+      | param name                      | param value          |
+      | spec.schedules[0].scheduleFrom  | 2024-01-01T00:00:00Z |
+      | spec.schedules[0].scheduleUntil | 2024-12-31T00:00:00Z |
+      | spec.schedules[1].scheduleFrom  | 2024-01-01T00:00:00Z |
+      | spec.schedules[1].scheduleUntil | 2024-12-31T00:00:00Z |
     When crossplane renders the composition
     Then check that no resources are provisioning
-    # TODO follow the example from service-account.feature and write similar steps to test the policy scheduler composition
+
+  @critial
+  Scenario: do not allow role creation when the schedule start time is after the end time
+   Given input claim is changed with parameters
+     | param name                      | param value          |
+     | spec.schedules[0].scheduleFrom  | 2031-01-01T00:00:00Z |
+     | spec.schedules[0].scheduleUntil | 2024-12-31T00:00:00Z |
+     | spec.schedules[1].scheduleFrom  | 2031-01-01T00:00:00Z |
+     | spec.schedules[1].scheduleUntil | 2024-12-31T00:00:00Z |
+   And input composition composition.yaml
+   When crossplane renders the composition
+   Then check that no resources are provisioning
+
+  @critial
+  Scenario: role should not be created when date-time formatting is invalid
+   Given input claim is changed with parameters
+     | param name                      | param value          |
+     | spec.schedules[0].scheduleFrom  | 2031-13-01T00:00:00Z |
+   Then rendering fails with error message containing "month out of range"
+
+   Given input claim is changed with parameters
+     | param name                      | param value          |
+     | spec.schedules[0].scheduleFrom  | 2031-12-32T00:00:00Z |
+   Then rendering fails with error message containing "day out of range"
+
+   Given input claim is changed with parameters
+     | param name                      | param value      |
+     | spec.schedules[0].scheduleFrom  | 2031-12-01T00:00 |
+   Then rendering fails with error message containing "cannot parse"
+
+   Given input claim is changed with parameters
+     | param name                      | param value          |
+     | spec.schedules[0].scheduleFrom  | 01-01-2025T00:00:00Z |
+   Then rendering fails with error message containing "error calling mustToDate"

--- a/test/composition-tests/policy-scheduler/resources/xr.yaml
+++ b/test/composition-tests/policy-scheduler/resources/xr.yaml
@@ -1,0 +1,32 @@
+# Copyright 2023 Swisscom (Schweiz) AG
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: policyscheduler.example.com/v1alpha1
+kind: XPolicyScheduler
+metadata:
+  labels:
+    crossplane.io/claim-name: scheduler-production
+    crossplane.io/claim-namespace: app
+  name: scheduler-production
+spec:
+  schedules:
+  - policyArn: arn:aws:iam::aws:policy/AmazonPolicy1
+    roleName: role-app-1
+    scheduleFrom: 2023-01-01T00:00:00Z
+    scheduleUntil: 2023-12-31T23:59:59Z
+  - policyArn: arn:aws:iam::aws:policy/AmazonPolicy2
+    roleName: role-app-2
+    scheduleFrom: 2023-01-01T00:00:00Z
+    scheduleUntil: 2023-12-31T23:59:59Z

--- a/test/pkg/policy-scheduler/composition.yaml
+++ b/test/pkg/policy-scheduler/composition.yaml
@@ -1,0 +1,55 @@
+# Copyright 2023 Swisscom (Schweiz) AG
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xpolicyscheduler.aws.example.com
+spec:
+  compositeTypeRef:
+    apiVersion: policyscheduler.example.com/v1alpha1
+    kind: XPolicyScheduler
+  mode: Pipeline
+  pipeline:
+  - step: environmentConfigs
+    functionRef:
+      name: function-environment-configs
+    input:
+      apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+      kind: Input
+      spec:
+        environmentConfigs:
+        - type: Reference
+          ref:
+            name: envconfig
+  - functionRef:
+      name: function-go-templating
+    step: sample-step-1
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: Inline
+      inline:
+        template: |-
+          {{/* TODO: implement the composition with one or more steps. The function can be any function from https://github.com/crossplane-contrib?q=function or custom one. Explain your choice. */}}
+          {{/* TODO: the composition must: */}}
+          {{/*  1. handle all schedules from the schedules list */}}
+          {{/*  2. for each schedule: provision the role and assign the policy ONLY during the time interval specified by the scheduleFrom and scheduleUntil */}}
+          {{/* TODO: write composition tests to demonstrate how the composition functions; write as many relevant tests as you consider. Justify the choices made! */}}
+          {{/* HINT 1: Make use of tags to run a sub set of tests. For example: ./tests_runner.sh test -t PolicyScheduler -t normal */}}
+          {{/* HINT 2: Make use of debug flag to get the observed and desired states of each crossplane iteration. Check ./dump folder. For example: ./tests_runner.sh test -d */}}
+
+  - step: automatically-detect-ready-composed-resources
+    functionRef:
+      name: function-auto-ready

--- a/test/pkg/policy-scheduler/composition.yaml
+++ b/test/pkg/policy-scheduler/composition.yaml
@@ -35,20 +35,90 @@ spec:
             name: envconfig
   - functionRef:
       name: function-go-templating
-    step: sample-step-1
+    step: create-scheduled-roles
     input:
       apiVersion: gotemplating.fn.crossplane.io/v1beta1
       kind: GoTemplate
       source: Inline
       inline:
         template: |-
-          {{/* TODO: implement the composition with one or more steps. The function can be any function from https://github.com/crossplane-contrib?q=function or custom one. Explain your choice. */}}
-          {{/* TODO: the composition must: */}}
-          {{/*  1. handle all schedules from the schedules list */}}
-          {{/*  2. for each schedule: provision the role and assign the policy ONLY during the time interval specified by the scheduleFrom and scheduleUntil */}}
-          {{/* TODO: write composition tests to demonstrate how the composition functions; write as many relevant tests as you consider. Justify the choices made! */}}
-          {{/* HINT 1: Make use of tags to run a sub set of tests. For example: ./tests_runner.sh test -t PolicyScheduler -t normal */}}
-          {{/* HINT 2: Make use of debug flag to get the observed and desired states of each crossplane iteration. Check ./dump folder. For example: ./tests_runner.sh test -d */}}
+          {{ $accountId := (index .context "apiextensions.crossplane.io/environment").accountId }}
+          {{ $region := (index .context "apiextensions.crossplane.io/environment").region }}
+          {{ $eksOID := (index .context "apiextensions.crossplane.io/environment").eksOID }}
+
+          {{- range .observed.composite.resource.spec.schedules }}
+
+          {{- if and .scheduleFrom .scheduleUntil .roleName .policyArn }}
+
+          {{- $now := now | date "2006-01-02T15:04:05Z" }}
+
+          {{/* Use mustToDate to validte date format */}}
+          {{- $start := mustToDate "2006-01-02T15:04:05Z" .scheduleFrom | date "2006-01-02T15:04:05Z" }}
+          {{- $end := mustToDate "2006-01-02T15:04:05Z" .scheduleUntil | date "2006-01-02T15:04:05Z" }}
+
+          {{/* Create role when schedule date is within the schedule window */}}
+
+          {{- if and (ge $now $start) (le $now $end) }}
+          ---
+          apiVersion: iam.aws.crossplane.io/v1beta1
+          kind: Role
+          metadata:
+            name: {{ .roleName }}
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: {{ .roleName }}
+              gotemplating.fn.crossplane.io/schedule-until: {{ $end }}
+          spec:
+            forProvider:
+              assumeRolePolicyDocument: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {
+                        "Federated": "arn:aws:iam::{{$accountId}}:oidc-provider/oidc.eks.{{$region}}.amazonaws.com/id/{{$eksOID}}"
+                      },
+                      "Action": "sts:AssumeRoleWithWebIdentity",
+                      "Condition": {
+                        "StringLike": {
+                          "oidc.eks.{{$region}}.amazonaws.com/id/{{$eksOID}}:aud": "sts.amazonaws.com"
+                        }
+                      }
+                    }
+                  ]
+                }
+              permissionsBoundary: arn:aws:iam::{{$accountId}}:policy/sc-policy-cdk-pipeline-permission-boundary
+              description: managed by crossplane
+              tags:
+                - key: Source
+                  value: "xPolicyScheduler"
+            providerConfigRef:
+              name: providerconfig-aws
+
+          {{/* attach policy when role is ready */}}
+
+          {{ if and (ne $.observed.resources nil) (ne ( index $.observed.resources .roleName) nil) }}
+          {{ if eq (( index $.observed.resources .roleName) | getResourceCondition "Ready").Status "True" }}
+          ---
+          apiVersion: iam.aws.crossplane.io/v1beta1
+          kind: RolePolicyAttachment
+          metadata:
+            name: {{ .roleName }}-rpa
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: {{ .roleName }}-rpa
+          spec:
+            forProvider:
+              policyArn: {{ .policyArn }}
+              roleName: {{ .roleName }}
+            providerConfigRef:
+              name: providerconfig-aws
+          {{- end }}
+          {{- end }}
+
+
+          {{- end }}
+          {{- end }}
+          {{- end }}
 
   - step: automatically-detect-ready-composed-resources
     functionRef:

--- a/test/pkg/policy-scheduler/definition.yaml
+++ b/test/pkg/policy-scheduler/definition.yaml
@@ -1,0 +1,41 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpolicyscheduler.example.com
+spec:
+  group: policyscheduler.example.com
+  names:
+    kind: XPolicyScheduler
+    plural: xpolicyschedulers
+  enforcedCompositionRef:
+    name: xpolicyscheduler.aws.example.com
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                schedules:
+                  type: array
+                  description: list of schedules
+                  items:
+                    type: object
+                    description: Description of the schedule of the policy assignment to the role. The role must be provisioned and must have the policy assigned ONLY during the time interval (from->until)
+                    properties:
+                      roleName:
+                        type: string
+                        description: The role to provision and attach the policy to
+                      policyArn:
+                        type: string
+                        description: The policy ARN to attach to the role
+                      scheduleFrom:
+                        type: string
+                        description: TODO adapt the format of the time as it fits better for usability and handling in the composition
+                      scheduleUntil:
+                        type: string
+                        description: TODO adapt the format of the time as it fits better for usability and handling in the composition

--- a/test/pkg/policy-scheduler/definition.yaml
+++ b/test/pkg/policy-scheduler/definition.yaml
@@ -35,7 +35,9 @@ spec:
                         description: The policy ARN to attach to the role
                       scheduleFrom:
                         type: string
-                        description: TODO adapt the format of the time as it fits better for usability and handling in the composition
+                        format: date-time
+                        description: Start of the schedule (RFC3339 date-time, e.g. 2023-01-01T00:00:00Z)
                       scheduleUntil:
                         type: string
-                        description: TODO adapt the format of the time as it fits better for usability and handling in the composition
+                        format: date-time
+                        description: End of the schedule (RFC3339 date-time, e.g. 2023-12-31T23:59:59Z)


### PR DESCRIPTION
## Description

This PR adds a new step to the policy scheduler composition that creates roles based on user-defined schedules. It pulls relevant environment variables like account ID and region, and processes each schedule only if the required fields are set.

I also updated the schema to enforce proper RFC3339 date-time formatting for the schedule fields, making sure the input is clear and consistent.

### Testing

On the testing side, I added several new scenarios to cover:

- Creating roles within the scheduled time window
- Preventing role creation outside of that window
- Handling cases where the schedule start time is after the end time
- Validating that invalid date formats cause rendering errors with helpful messages

These tests help ensure the scheduler behaves correctly and fails gracefully when given bad input.

### Future improvements

Supporting cron-based schedule expressions would be a valuable enhancement, offering users greater flexibility. I attempted to implement this but ran into some challenges. For now, I opted for a simpler approach using fixed date windows.